### PR TITLE
PR: ワークフロー追加

### DIFF
--- a/.github/workflows/auto-close-issue.yml
+++ b/.github/workflows/auto-close-issue.yml
@@ -1,0 +1,34 @@
+name: Auto Close Issues With Action
+
+on:
+  pull_request:
+    types: [closed]
+    branches: ["*"]
+
+jobs:
+  auto-close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Close issues fixed in this PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          ISSUE_NUMBERS=$(echo "$PR_BODY" | grep -o -E 'close\s+(https://github\.com/[^/]+/[^/]+/issues/[0-9]+|issues/[0-9]+|#[0-9]+)' | grep -o '[0-9]\+')
+
+          for ISSUE_NUMBER in $ISSUE_NUMBERS; do
+            curl -X PATCH \
+              -H "Authorization: token $GH_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER" \
+              -d '{"state":"closed"}'
+            
+            curl -X POST \
+              -H "Authorization: token $GH_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments" \
+              -d "{\"body\":\"このイシューはPR #${{ github.event.pull_request.number }} のマージによって解決されました。\"}"
+          done


### PR DESCRIPTION
### 目的
新規に .github/workflows/auto-close-issue.yml を追加し、PRクローズ時（マージのみ）に本文中の close #123 等へ言及しているイシューを自動クローズする仕組みを導入しました。

### 機能概要
各イシューに「このイシューはPR #<番号> のマージによって解決されました。」というコメントを自動投稿します。
マージ済みPRで、以下の表記が含まれている場合に発火することを想定しています。
* 数字 形式（例：#000）
   close #100

* URL 形式（例：https://github.com/nichicom/nolab-app/issues/000）
   close https://github.com/nichicom/nolab-app/issues/2136

### Testing
他リポジトリで動作確認済み。

