### PR TITLE
[Issue #100] バグ対応：静的レンダリングエラー対応

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -3,6 +3,8 @@ import { listTasksAction } from "@/features/tasks/actions/listTasksAction";
 import { getAllTasksPomodoroMinutesAction } from "@/features/pomodoro/actions/getAllTasksPomodoroMinutesAction";
 import DashboardContainer from "@/features/dashboard/components/DashboardContainer";
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: "ダッシュボード",
   description: "タスク一覧を表示します。",


### PR DESCRIPTION
# 変更内容
- Next.jsがダッシュボードが静的レンダリングする際に以下のエラーが発生しました。
- force-dynamicを明示的に設定し、動的レンダリングを行うように修正を行いました。

`Failed to load pomodoro minutes: Error: Dynamic server usage: Route /dashboard couldn't be rendered statically because it used `cookies`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error    at s (.next/server/chunks/586.js:1:28326)    at n (.next/server/app/(app)/dashboard/page.js:1:13784)    at cA (.next/server/app/(app)/dashboard/page.js:81:64)    at k (.next/server/app/(app)/dashboard/page.js:27:47902)    at i (.next/server/app/(app)/dashboard/page.js:88:4541)    at stringify (<anonymous>) {  description: "Route /dashboard couldn't be rendered statically because it used `cookies`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error",  digest: 'DYNAMIC_SERVER_USAGE'}
`

# Issue
#100 

# 確認内容
- ローカル環境でビルド時、上記エラーが発生しないことを確認しました。