### PR TITLE
Vitest Configに除外パス追加

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "jsdom",
-    exclude: ["**/node_modules/**", "e2e/**"],
+    exclude: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/.{idea,git,cache,output,temp}/**",
+      "**/{e2e,playwright}/**",
+    ],
   },
 });


### PR DESCRIPTION
Vitest Configに除外パス追加して`npm run test`でVitest実行のみにする

#106 