### PR TITLE
GitHub ActionsにE2Eテストワークフローを追加

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,9 +71,6 @@ jobs:
       - name: output service logs
         if: failure()
         run: |
-          echo "=== Supabase Logs ==="
-          supabase logs --tail 100
-          echo ""
           echo "=== Docker Containers ==="
           docker ps -a
 

--- a/e2e/helper/mailpit.ts
+++ b/e2e/helper/mailpit.ts
@@ -136,7 +136,7 @@ export class MailpitHelper {
         url.includes("token=")
     );
     let fixedLink = confirmLink?.replace(/\\u0026/g, "&");
-    fixedLink = fixedLink?.replace("127.0.0.1", "host.docker.internal");
+    fixedLink = fixedLink?.replace("127.0.0.1", "localhost");
     return fixedLink || null;
   }
 


### PR DESCRIPTION
## 概要
GitHub ActionsでE2Eテストを実行するためのワークフローを追加しました。

## 変更内容
### 追加
- `.github/workflows/e2e.yml` を新規作成
  - PRに対してE2Eテストを自動実行するワークフロー
  - Supabaseローカル環境のセットアップ
  - Drizzleマイグレーションの自動実行
  - Playwrightによるテスト実行
  - テスト失敗時のレポート保存機能

### 修正
- `e2e/helper/mailpit.ts`
  - メール確認リンクのホスト名を `host.docker.internal` から `localhost` に変更
  - CI環境での正しい動作を保証

## ワークフローの主な機能
- ✅ Node.js 20環境のセットアップ
- ✅ Supabase CLI によるローカルDB起動
- ✅ Drizzle マイグレーション自動実行
- ✅ アプリケーションのビルドと起動
- ✅ サービスヘルスチェック（App, Supabase, Mailpit）
- ✅ Playwright によるE2Eテスト実行
- ✅ テスト失敗時のレポートアップロード（30日間保存）

## テスト内容
- [x] ワークフローが正常に実行される
- [x] Supabase環境が正しく起動する
- [x] アプリケーションが起動する
- [x] E2Eテストが実行される
  - https://github.com/gimmeglasses/ketchup/actions/runs/21332603137/job/61399630799
 

## 関連Issue
 #115